### PR TITLE
Bugfix when using the 'all' parameter and the query returns an empty collection

### DIFF
--- a/src/Paginators/EmptyPaginator.php
+++ b/src/Paginators/EmptyPaginator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Swis\JsonApi\Server\Paginators;
+
+use Illuminate\Pagination\AbstractPaginator;
+use Illuminate\Support\Collection;
+
+class EmptyPaginator extends AbstractPaginator
+{
+    protected $total;
+
+    public function __construct($items = [], $total = 0)
+    {
+        $this->items = $items instanceof Collection ? $items : Collection::make($items);
+        $this->total = 0;
+    }
+
+    public function toArray()
+    {
+        return [
+            'data' => $this->items->toArray(),
+            'from' => $this->firstItem(),
+            'path' => $this->path,
+            'to' => $this->lastItem(),
+            'total' => $this->total(),
+        ];
+    }
+
+    public function total()
+    {
+        return $this->total;
+    }
+}

--- a/src/Repositories/BaseApiRepository.php
+++ b/src/Repositories/BaseApiRepository.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Swis\JsonApi\Server\Exceptions\NotFoundException;
+use Swis\JsonApi\Server\Paginators\EmptyPaginator;
 use Swis\JsonApi\Server\Traits\HandlesRelationships;
 
 abstract class BaseApiRepository implements RepositoryInterface
@@ -47,6 +48,9 @@ abstract class BaseApiRepository implements RepositoryInterface
         if (array_key_exists('all', $this->parameters)) {
             $collection = $this->query->get();
             $total = count($collection);
+            if (0 == $total) {
+                return new EmptyPaginator();
+            }
 
             return new LengthAwarePaginator($collection, $total, $total);
         }

--- a/tests/Unit/EmptyPaginatorTest.php
+++ b/tests/Unit/EmptyPaginatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Swis\JsonApi\Server\Paginators;
+
+use Tests\TestCase;
+
+class EmptyPaginatorTest extends TestCase
+{
+    /** @var EmptyPaginator */
+    private $emptyPaginator;
+
+    protected function setUp()
+    {
+        $this->emptyPaginator = new EmptyPaginator();
+    }
+
+    /** @test */
+    public function test_total()
+    {
+        $this->assertEquals(0, $this->emptyPaginator->total());
+    }
+
+    /** @test */
+    public function test_to_array()
+    {
+        $this->assertEquals([], $this->emptyPaginator->toArray()['data']);
+        $this->assertEquals(0, $this->emptyPaginator->toArray()['total']);
+    }
+}

--- a/tests/Unit/RepositoryTest.php
+++ b/tests/Unit/RepositoryTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Swis\JsonApi\Server\Exceptions\NotFoundException;
+use Swis\JsonApi\Server\Paginators\EmptyPaginator;
 use Tests\TestCase;
 use Tests\TestClasses\TestModel;
 use Tests\TestClasses\TestRepository;
@@ -116,6 +117,13 @@ class RepositoryTest extends TestCase
     public function paginate_with_all_attribute()
     {
         $this->assertEquals(1, $this->testRepository->paginate($parameters = ['all' => true])->total());
+    }
+
+    /** @test */
+    public function paginate_with_all_attribute_empty_collection()
+    {
+        $result = $this->testRepositoryWithRelationships->paginate(['all' => true]);
+        $this->assertInstanceOf(EmptyPaginator::class, $result);
     }
 
     /** @test */


### PR DESCRIPTION
Currently when the collection is empty it divides the $total by $total, when $total is 0 this results in a DivisionByZeroException. This resolves that issue.