### PR TITLE
Route stub bug generated a route with the controller action `destroy` ins…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Fixed 
 
 - Fix inconsistent url in `authentication_test.stub` (issue #8)
+- Route stub generated a route with the controller action `destroy` instead of `delete` (issue #9)
 
 ## 0.3.0
 

--- a/resources/templates/route.stub
+++ b/resources/templates/route.stub
@@ -5,7 +5,7 @@ use App\Http\Controllers\Api\$MODEL_NAME$Controller as Controller;
 Route::prefix('$PLURAL_SNAKE_CASED_MODEL_NAME$')->middleware('auth:api')->group(function () {
     Route::get('', Controller::class . '@index');
     Route::get('/{id}', Controller::class . '@show');
-    Route::delete('/{id}', Controller::class . '@destroy');
+    Route::delete('/{id}', Controller::class . '@delete');
     Route::post('', Controller::class . '@create');
     Route::patch('/{id}', Controller::class . '@update');
 });


### PR DESCRIPTION
Route stub bug generated a route with the controller action `destroy` instead of `delete`.

Fixes issue #9