### PR TITLE
Server should allow using the `Accept` header in requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 - Fix inconsistent url in `authentication_test.stub` (issue #8)
 - Route stub generated a route with the controller action `destroy` instead of `delete` (issue #9)
+- As per specification, the server should allow using the `Accept` header in requests. (issue #12)
 
 ## 0.3.0
 

--- a/src/Http/Middleware/InspectContentType.php
+++ b/src/Http/Middleware/InspectContentType.php
@@ -18,7 +18,7 @@ class InspectContentType
      */
     public function handle(Request $request, Closure $next)
     {
-        if ('application/vnd.api+json' !== $request->header('Content-Type')) {
+        if ('application/vnd.api+json' !== $request->header('Content-Type') && 'application/vnd.api+json' !== $request->header('Accept')) {
             throw new ContentTypeNotSupportedException('Your request should be in json api format. (Content-Type: application/vnd.api+json)');
         }
 

--- a/tests/Unit/InspectContentTypeTest.php
+++ b/tests/Unit/InspectContentTypeTest.php
@@ -51,4 +51,17 @@ class InspectContentTypeTest extends TestCase
         });
         $this->assertEquals($response, null);
     }
+
+    /**
+     * @test
+     *
+     * @throws ContentTypeNotSupportedException
+     */
+    public function itDoesNotThrowNotSupportedExceptionWhenUsingAcceptHeader()
+    {
+        $this->request->headers->set('Accept', 'application/vnd.api+json');
+        $response = $this->middleware->handle($this->request, function () {
+        });
+        $this->assertEquals($response, null);
+    }
 }


### PR DESCRIPTION
As per specification, the server should allow using the `Accept` header in requests.

Added test for `Accept` header and added header to the middleware check.

Fixes issue #12