### PR TITLE
Server content type response and escaping slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All Notable changes to `json-api-server` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## Unreleased
+
+### Fixed
+
+- Server should always respond with `Content-type: application/vnd.api+json`
+
 ## 0.3.3
 
 ### Fixed
@@ -11,7 +17,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - The `authentication_test.stub` called `PUT` instead of `PATCH` (issue #14)
 
 ## 0.3.2
-
+self
 ### Fixed
 
 - Enable disable middleware for tests and add "Accept: application/vnd.api+json" header when running test calls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Fixed
 
 - Server should always respond with `Content-type: application/vnd.api+json`
+- Server should not escape slashes in responses (issue #11)
 
 ## 0.3.3
 

--- a/src/Services/ResponseService.php
+++ b/src/Services/ResponseService.php
@@ -21,10 +21,10 @@ class ResponseService
         if ($responseModel instanceof RespondError) {
             $errors = $this->formatErrors($responseModel, $content);
 
-            return response()->json($errors, $responseModel->getStatusCode(), ['Content-Type' => 'application/vnd.api+json']);
+            return response()->json($errors, $responseModel->getStatusCode(), ['Content-Type' => 'application/vnd.api+json'], JSON_UNESCAPED_SLASHES);
         }
 
-        return response()->json($content, $responseModel->getStatusCode(), ['Content-Type' => 'application/vnd.api+json']);
+        return response()->json($content, $responseModel->getStatusCode(), ['Content-Type' => 'application/vnd.api+json'], JSON_UNESCAPED_SLASHES);
     }
 
     public function respondWithResourceCollection($strResponseModel, $content)
@@ -33,6 +33,7 @@ class ResponseService
 
         return (new BaseApiCollectionResource($content))
             ->response()
+            ->setEncodingOptions(JSON_UNESCAPED_SLASHES)
             ->header('Content-Type', 'application/vnd.api+json')
             ->setStatusCode($responseModel->getStatusCode());
     }
@@ -46,6 +47,7 @@ class ResponseService
 
         return (new BaseApiResource($content))
             ->response()
+            ->setEncodingOptions(JSON_UNESCAPED_SLASHES)
             ->header('Content-Type', 'application/vnd.api+json')
             ->setStatusCode($responseModel->getStatusCode());
     }

--- a/src/Services/ResponseService.php
+++ b/src/Services/ResponseService.php
@@ -21,10 +21,10 @@ class ResponseService
         if ($responseModel instanceof RespondError) {
             $errors = $this->formatErrors($responseModel, $content);
 
-            return response($errors, $responseModel->getStatusCode());
+            return response()->json($errors, $responseModel->getStatusCode(), ['Content-Type' => 'application/vnd.api+json']);
         }
 
-        return response($content, $responseModel->getStatusCode());
+        return response()->json($content, $responseModel->getStatusCode(), ['Content-Type' => 'application/vnd.api+json']);
     }
 
     public function respondWithResourceCollection($strResponseModel, $content)
@@ -33,6 +33,7 @@ class ResponseService
 
         return (new BaseApiCollectionResource($content))
             ->response()
+            ->header('Content-Type', 'application/vnd.api+json')
             ->setStatusCode($responseModel->getStatusCode());
     }
 
@@ -45,6 +46,7 @@ class ResponseService
 
         return (new BaseApiResource($content))
             ->response()
+            ->header('Content-Type', 'application/vnd.api+json')
             ->setStatusCode($responseModel->getStatusCode());
     }
 

--- a/tests/Unit/HandleResponsesTest.php
+++ b/tests/Unit/HandleResponsesTest.php
@@ -9,6 +9,7 @@
 namespace Tests\Unit;
 
 use Swis\JsonApi\Server\Traits\HandleResponses;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Tests\TestCase;
 use Tests\TestClasses\TestModel;
 
@@ -29,6 +30,7 @@ class HandleResponsesTest extends TestCase
         $response = $this->mock->respondWithForbidden('FORBIDDEN');
 
         $this->assertEquals('FORBIDDEN', json_decode($response->getContent())->errors[0]->detail);
+        $this->assertEquals('application/vnd.api+json', $response->headers->get('Content-Type'));
         $this->assertEquals(403, $response->getStatusCode());
     }
 
@@ -38,6 +40,7 @@ class HandleResponsesTest extends TestCase
         $response = $this->mock->respondWithBadRequest('BAD REQUEST');
 
         $this->assertEquals('BAD REQUEST', json_decode($response->getContent())->errors[0]->detail);
+        $this->assertEquals('application/vnd.api+json', $response->headers->get('Content-Type'));
         $this->assertEquals(400, $response->getStatusCode());
     }
 
@@ -47,6 +50,7 @@ class HandleResponsesTest extends TestCase
         $response = $this->mock->respondWithNotFound('NOT FOUND');
 
         $this->assertEquals('NOT FOUND', json_decode($response->getContent())->errors[0]->detail);
+        $this->assertEquals('application/vnd.api+json', $response->headers->get('Content-Type'));
         $this->assertEquals(404, $response->getStatusCode());
     }
 
@@ -56,9 +60,12 @@ class HandleResponsesTest extends TestCase
         $model = new TestModel();
         $model->body = 'TEST';
         $response = $this->mock->respondWithCollection($model);
+
+
         $responseBody = json_decode($response->getContent())->data;
 
         $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('application/vnd.api+json', $response->headers->get('Content-Type'));
         $this->assertEquals('TEST', $responseBody->attributes->body);
     }
 }

--- a/tests/Unit/HandleResponsesTest.php
+++ b/tests/Unit/HandleResponsesTest.php
@@ -9,7 +9,6 @@
 namespace Tests\Unit;
 
 use Swis\JsonApi\Server\Traits\HandleResponses;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Tests\TestCase;
 use Tests\TestClasses\TestModel;
 
@@ -60,7 +59,6 @@ class HandleResponsesTest extends TestCase
         $model = new TestModel();
         $model->body = 'TEST';
         $response = $this->mock->respondWithCollection($model);
-
 
         $responseBody = json_decode($response->getContent())->data;
 


### PR DESCRIPTION
## Description

Server did not repsond with correct header, and slashes inside `links` were escaped by json encode.

## Motivation and context

Comply with spec, and remove escaping.

## How has this been tested?

Tests for headers are added, response tested in test project.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [ ] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
