### PR TITLE
#20 PHP 7.2 count bug fix

### DIFF
--- a/src/Http/Resources/BaseApiResource.php
+++ b/src/Http/Resources/BaseApiResource.php
@@ -165,7 +165,7 @@ class BaseApiResource extends Resource
             }
 
             $data = $this->resource->$relationship;
-            if (0 == count($data)) {
+            if ($data instanceof Countable && 0 == count($data)) {
                 continue;
             }
 


### PR DESCRIPTION
7.2PHP count warning if return Object and not Collection

<!--- Provide a general summary of your changes in the Title above -->

## Description

PHP 7.2 throw warning if want to count not countable

## Motivation and context

It solves BelongsTo, HasOne relationships, because it return model object, with is not countable 

## How has this been tested?

Tested on PHP 7.0, and PHP 7.2, with relations and without

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [ ] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
